### PR TITLE
Add support for overriding config.json with environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ tests/visual/snapshots/**/*
 # IDEs and Editors
 .idea
 .vscode
+
+# Local Files
+*.local

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -9,5 +9,9 @@ interface ImportMeta extends Readonly<Record<string, unknown>> {
     PROD: boolean;
     DEV: boolean;
     SSR: boolean;
+    VITE_CONFIG_NODES?: string;
+    VITE_CONFIG_SUPPORT_WEBSITE?: string;
+    VITE_CONFIG_FALLBACK_PREFERRED_SEED?: string;
+    VITE_CONFIG_PLUGINS?: string;
   };
 }


### PR DESCRIPTION
- Added optional environment variables for each top level property in `src/config.json`
- If present, the variables are validated against the config schema and merged with the existing properties from `src/config.json`
- For object properties, a stringified JSON is expected. Not all properties need to be present, any missing properties will be added from `src/config.json`

For the matter at hand, configuring the planning boards through env vars would something look like this:
```.env
VITE_CONFIG_PLUGINS="{"radiclePlanningBoards":{"enabled":true,"origin":"https://somedomain.com"}}"
```